### PR TITLE
Fix dependencies in libctr9.pc

### DIFF
--- a/libctr9.pc.in
+++ b/libctr9.pc.in
@@ -8,6 +8,6 @@ Description: Baremetal ARM9 library for the Nintendo 3DS
 URL: https://github.com/gemarcano/@PACKAGE_NAME@
 Version: @VERSION@
 Requires.private: libctr_core
-Libs: -L$(libdir) -lctr9 -lfreetype2 -lctrelf
-Cflags: -I(includedir)
+Libs: -L$(libdir) -lctr9 -lfreetype -lctrelf
+Cflags: -I$(includedir)
 

--- a/libctr9.pc.in
+++ b/libctr9.pc.in
@@ -7,7 +7,7 @@ Name: @PACKAGE_NAME@
 Description: Baremetal ARM9 library for the Nintendo 3DS
 URL: https://github.com/gemarcano/@PACKAGE_NAME@
 Version: @VERSION@
-Requires.private: ctr_core
+Requires.private: libctr_core
 Libs: -L$(libdir) -lctr9 -lfreetype2 -lctrelf
 Cflags: -I(includedir)
 


### PR DESCRIPTION
On my system, libctr_core is detected by pkgconfig as `libctr_core`, not `ctr_core`. I assume this would be the same on other systems.